### PR TITLE
Update sahibinden.class.php

### DIFF
--- a/sahibinden.class.php
+++ b/sahibinden.class.php
@@ -171,7 +171,7 @@ class Sahibinden
      * @param $string
      * @return string
      */
-    private function replaceSpace( $string )
+    private static function replaceSpace( $string )
     {
         $string = preg_replace( "/\s+/", " ", $string );
         $string = trim( $string );
@@ -183,7 +183,7 @@ class Sahibinden
      * @param null $proxy
      * @return mixed
      */
-    private function Curl( $url, $proxy = NULL )
+    private static function Curl( $url, $proxy = NULL )
     {
         $options = array ( CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => false,


### PR DESCRIPTION
Curl ve replaceSpace için self:: kullanımlarında "Strict standards: Non-static method self::fonksiyonadi should not be called statically in  on line xx" hatası veriyor. private function yerine private static function kullanılınca hata düzeliyor.